### PR TITLE
Added better usage info for README, removed mention of bash alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Markdown preview made easy (with live update).
 ```
 
 ### Usage
+First, start the server with a given filename to preview.
+
 ```bash
   markdown-preview <filename> [options]
 ```
@@ -16,6 +18,8 @@ Or add an alias for it in your `.bash_profile`:
 ```bash
   alias mp='markdown-preview'
 ```
+
+Next, see the preview by navigating in your browser to `http://localhost:<port>/<filename>`.
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,6 @@ First, start the server with a given filename to preview.
   markdown-preview <filename> [options]
 ```
 
-Or add an alias for it in your `.bash_profile`:
-```bash
-  alias mp='markdown-preview'
-```
-
 Next, see the preview by navigating in your browser to `http://localhost:<port>/<filename>`.
 
 ### Options


### PR DESCRIPTION
1) I had no idea how to use this module. I expected it to output the styled markdown preview into my terminal. Instead, you have to navigate to the server URL to see the preview. This is fine, but I think the README should make it a little more obvious how to see the finished preview.
2) I also removed the mention of bash aliases. I didn't think this had anything to do with markdown-preview, and those who really wish to use an alias would know how to create one anyway.